### PR TITLE
Remove leading slash from examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ to the old address.
 
 ```
 title : "A post about foo"
-alias : /old-foo.html
+alias : old-foo.html
 ```
 
 Now someone can visit your middleman site at `/old-foo.html` and they'll
@@ -55,7 +55,7 @@ directory.
 
 ```
 title : "A post about foo"
-alias : /old-foo/
+alias : old-foo/
 ```
 
 The example above will result in a redirect file being generated at


### PR DESCRIPTION
My builds were failing when the alias was prefixed with a slash. I removed the slash and build was successful.

```
== Request: /blog/2014/02/01/global-drupal-sprint-weekend/index.html
       error  /blog/2014/02/01/global-drupal-sprint-weekend/index.html
<html><body><h1>File Not Found</h1><p>/blog/2014/02/01/global-drupal-sprint-weekend/index.html</p></body>
There were errors during this build
```
