### PR TITLE
version bump to 0.0.9

### DIFF
--- a/lib/middleman-alias/version.rb
+++ b/lib/middleman-alias/version.rb
@@ -1,3 +1,3 @@
 module MiddlemanAlias
-  VERSION = "0.0.8"
+  VERSION = "0.0.9"
 end


### PR DESCRIPTION
I am looking to include the `alias: ["old1","old"]` syntax in a project and would like to attach to a semantic version.  Will you accept a version bump?
