### PR TITLE
Relative paths & frontmatter / metadata

### DIFF
--- a/features/alias.feature
+++ b/features/alias.feature
@@ -16,3 +16,25 @@ Feature: Aliases
     Then I should see "You are being redirected"
     When I go to "/foo-b.html"
     Then I should see "You are being redirected"
+
+  Scenario: Aliases should use relative paths if relative_links are enabled
+   Given a fixture app "alias-app"
+    And a file named "config.rb" with:
+    """
+    set :relative_links, true
+    activate :alias
+    """
+    And the Server is running
+    When I go to "/foo.html"
+    Then I should see 'href="bar.html'
+
+  Scenario: Aliases should use absolute paths if relative_links are disabled
+   Given a fixture app "alias-app"
+    And a file named "config.rb" with:
+    """
+    set :relative_links, false
+    activate :alias
+    """
+    And the Server is running
+    When I go to "/foo.html"
+    Then I should see 'href="/bar.html'

--- a/lib/middleman-alias/alias-resource.rb
+++ b/lib/middleman-alias/alias-resource.rb
@@ -43,7 +43,7 @@ module Middleman
       end
 
       def raw_data
-        {}
+        @alias_resource.raw_data
       end
 
       def ignored?
@@ -51,7 +51,7 @@ module Middleman
       end
 
       def metadata
-        @local_metadata.dup
+        @alias_resource.metadata
       end
 
 

--- a/lib/middleman-alias/alias-resource.rb
+++ b/lib/middleman-alias/alias-resource.rb
@@ -4,8 +4,8 @@ module Middleman
 
       attr_accessor :output
 
-      def initialize(store, path, alias_path)
-        @alias_path = alias_path
+      def initialize(store, path, alias_resource)
+        @alias_resource = alias_resource
         super(store, path)
       end
 
@@ -18,20 +18,21 @@ module Middleman
       end
 
       def render(*args, &block)
+        app.current_path = destination_path
         %[
           <html>
             <head>
-              <link rel="canonical" href="#{@alias_path}" />
+              <link rel="canonical" href="#{app.url_for(@alias_resource)}" />
               <meta name="robots" content="noindex,follow" />
               <meta http-equiv="cache-control" content="no-cache" />
               <script>
                 // Attempt to keep search and hash
-                window.location.replace("#{@alias_path}"+window.location.search+window.location.hash);
+                window.location.replace("#{app.url_for(@alias_resource)}"+window.location.search+window.location.hash);
               </script>
-              <meta http-equiv=refresh content="0; url=#{@alias_path}" />
+              <meta http-equiv=refresh content="0; url=#{app.url_for(@alias_resource)}" />
             </head>
             <body>
-              <a href="#{@alias_path}">You are being redirected.</a>
+              <a href="#{app.url_for(@alias_resource)}">You are being redirected.</a>
             </body>
           </html>
         ]

--- a/lib/middleman-alias/extension.rb
+++ b/lib/middleman-alias/extension.rb
@@ -16,7 +16,7 @@ module Middleman
             existing_resource = resources.select{|r| r.destination_path == alias_url }.first
             next if existing_resource
 
-            resources.push Middleman::Sitemap::AliasResource.new(@app.sitemap, alias_url, resource.url)
+            resources.push Middleman::Sitemap::AliasResource.new(@app.sitemap, alias_url, resource)
             #Sitemap::Resource.new(@app.sitemap, alias_url).tap do |p|
               #p.proxy_to("alias.html")
               #p.add_metadata locals: {

--- a/lib/middleman-alias/version.rb
+++ b/lib/middleman-alias/version.rb
@@ -1,3 +1,3 @@
 module MiddlemanAlias
-  VERSION = "0.0.11"
+  VERSION = "0.0.12"
 end


### PR DESCRIPTION
Add support for relative paths. Fixes issue #7.  Also allows treating the aliased resource more like a true resource & reference any frontmatter or other metadata from the original.