### PR TITLE
AliasResource says it's aliased source_file is it's source

### DIFF
--- a/lib/middleman-alias/alias-resource.rb
+++ b/lib/middleman-alias/alias-resource.rb
@@ -10,7 +10,7 @@ module Middleman
       end
 
       def source_file
-        nil
+        @alias_resource.source_file
       end
 
       def template?


### PR DESCRIPTION
If it says `nil`, middleman's sitemap (http://localhost:4567/__middleman/sitemap/) fails with a `NoMethodError`. We could return `""` instead, but I think it's correct to think the source file of the alias is the aliased source file.

```
NoMethodError: undefined method `sub' for nil:NilClass
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/middleman-core-3.3.3/lib/middleman-core/meta_pages/sitemap_resource.rb:43:in `resource_properties'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/middleman-core-3.3.3/lib/middleman-core/meta_pages/sitemap_resource.rb:20:in `block (2 levels) in render'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/padrino-helpers-0.12.2/lib/padrino-helpers/output_helpers.rb:65:in `call'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/padrino-helpers-0.12.2/lib/padrino-helpers/output_helpers.rb:65:in `capture_html'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/padrino-helpers-0.12.2/lib/padrino-helpers/tag_helpers.rb:122:in `content_tag'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/middleman-core-3.3.3/lib/middleman-core/meta_pages/sitemap_resource.rb:18:in `block in render'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/padrino-helpers-0.12.2/lib/padrino-helpers/output_helpers.rb:65:in `call'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/padrino-helpers-0.12.2/lib/padrino-helpers/output_helpers.rb:65:in `capture_html'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/padrino-helpers-0.12.2/lib/padrino-helpers/tag_helpers.rb:122:in `content_tag'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/middleman-core-3.3.3/lib/middleman-core/meta_pages/sitemap_resource.rb:17:in `render'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/middleman-core-3.3.3/lib/middleman-core/meta_pages/sitemap_tree.rb:42:in `block in render'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/middleman-core-3.3.3/lib/middleman-core/meta_pages/sitemap_tree.rb:36:in `each'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/middleman-core-3.3.3/lib/middleman-core/meta_pages/sitemap_tree.rb:36:in `reduce'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/middleman-core-3.3.3/lib/middleman-core/meta_pages/sitemap_tree.rb:36:in `render'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/middleman-core-3.3.3/lib/middleman-core/meta_pages/sitemap_tree.rb:42:in `block in render'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/middleman-core-3.3.3/lib/middleman-core/meta_pages/sitemap_tree.rb:36:in `each'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/middleman-core-3.3.3/lib/middleman-core/meta_pages/sitemap_tree.rb:36:in `reduce'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/middleman-core-3.3.3/lib/middleman-core/meta_pages/sitemap_tree.rb:36:in `render'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/middleman-core-3.3.3/lib/middleman-core/meta_pages/sitemap_tree.rb:42:in `block in render'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/middleman-core-3.3.3/lib/middleman-core/meta_pages/sitemap_tree.rb:36:in `each'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/middleman-core-3.3.3/lib/middleman-core/meta_pages/sitemap_tree.rb:36:in `reduce'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/middleman-core-3.3.3/lib/middleman-core/meta_pages/sitemap_tree.rb:36:in `render'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/middleman-core-3.3.3/lib/middleman-core/meta_pages/sitemap_tree.rb:42:in `block in render'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/middleman-core-3.3.3/lib/middleman-core/meta_pages/sitemap_tree.rb:36:in `each'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/middleman-core-3.3.3/lib/middleman-core/meta_pages/sitemap_tree.rb:36:in `reduce'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/middleman-core-3.3.3/lib/middleman-core/meta_pages/sitemap_tree.rb:36:in `render'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/middleman-core-3.3.3/lib/middleman-core/meta_pages/sitemap_tree.rb:42:in `block in render'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/middleman-core-3.3.3/lib/middleman-core/meta_pages/sitemap_tree.rb:36:in `each'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/middleman-core-3.3.3/lib/middleman-core/meta_pages/sitemap_tree.rb:36:in `reduce'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/middleman-core-3.3.3/lib/middleman-core/meta_pages/sitemap_tree.rb:36:in `render'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/middleman-core-3.3.3/lib/middleman-core/meta_pages/templates/sitemap.html.erb:26:in `block in singletonclass'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/middleman-core-3.3.3/lib/middleman-core/meta_pages/templates/sitemap.html.erb:65530:in `instance_eval'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/middleman-core-3.3.3/lib/middleman-core/meta_pages/templates/sitemap.html.erb:65530:in `singletonclass'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/middleman-core-3.3.3/lib/middleman-core/meta_pages/templates/sitemap.html.erb:65528:in `__tilt_70178051877780'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/tilt-1.4.1/lib/tilt/template.rb:170:in `call'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/tilt-1.4.1/lib/tilt/template.rb:170:in `evaluate'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/tilt-1.4.1/lib/tilt/template.rb:103:in `render'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/middleman-core-3.3.3/lib/middleman-core/meta_pages.rb:93:in `template'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/middleman-core-3.3.3/lib/middleman-core/meta_pages.rb:57:in `sitemap'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/rack-1.5.2/lib/rack/builder.rb:138:in `call'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/rack-1.5.2/lib/rack/builder.rb:138:in `call'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/rack-1.5.2/lib/rack/urlmap.rb:65:in `block in call'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/rack-1.5.2/lib/rack/urlmap.rb:50:in `each'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/rack-1.5.2/lib/rack/urlmap.rb:50:in `call'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/rack-1.5.2/lib/rack/static.rb:119:in `call'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/rack-1.5.2/lib/rack/builder.rb:138:in `call'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/middleman-core-3.3.3/lib/middleman-core/meta_pages.rb:39:in `call'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/rack-1.5.2/lib/rack/builder.rb:138:in `call'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/rack-1.5.2/lib/rack/urlmap.rb:65:in `block in call'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/rack-1.5.2/lib/rack/urlmap.rb:50:in `each'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/rack-1.5.2/lib/rack/urlmap.rb:50:in `call'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/rack-1.5.2/lib/rack/showexceptions.rb:24:in `call'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/rack-1.5.2/lib/rack/head.rb:11:in `call'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/rack-1.5.2/lib/rack/lint.rb:49:in `_call'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/rack-1.5.2/lib/rack/lint.rb:37:in `call'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/rack-1.5.2/lib/rack/builder.rb:138:in `call'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/rack-1.5.2/lib/rack/handler/webrick.rb:60:in `service'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/1.9.1/webrick/httpserver.rb:138:in `service'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/1.9.1/webrick/httpserver.rb:94:in `run'
	/Users/mgarcia/.rbenv/versions/1.9.3-p484/lib/ruby/1.9.1/webrick/server.rb:191:in `block in start_thread'
```